### PR TITLE
Use openssl instead of ring.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 target/
 Cargo.lock
 node-server/node_modules/

--- a/hawk/Cargo.toml
+++ b/hawk/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hawk"
-version = "1.0.2"
-authors = ["Jonas Finnemann Jensen <jopsen@gmail.com>", "Dustin J. Mitchell <dustin@mozilla.com>"]
+version = "2.0.0"
+authors = ["Jonas Finnemann Jensen <jopsen@gmail.com>", "Dustin J. Mitchell <dustin@mozilla.com>", "Edouard Oger <eoger@mozilla.com>"]
 license = "MPL-2.0"
 readme = "README.md"
 repository = "https://github.com/taskcluster/rust-hawk"
@@ -10,12 +10,12 @@ homepage = "https://docs.rs/hawk/"
 description = "Hawk Implementation for Rust"
 
 [dev-dependencies]
-pretty_assertions = "^0.1.2"
+pretty_assertions = "0.5.1"
 
 [dependencies]
-base64 = "~0.6.0"
-ring = "^0.8.0"
-time = "^0.1.32"
-url = "1.4.0"
-rand = "0.3"
-error-chain = "^0.11.0-rc.2"
+base64 = "0.9.0"
+openssl = "0.10.7"
+time = "0.1.39"
+url = "1.7.0"
+rand = "0.4.2"
+error-chain = "0.11.0"

--- a/hawk/src/bewit.rs
+++ b/hawk/src/bewit.rs
@@ -114,14 +114,14 @@ mod test {
     use super::*;
     use std::str::FromStr;
     use credentials::Key;
-    use ring::digest;
+    use openssl::hash::{MessageDigest};
     use mac::{Mac, MacType};
 
     fn make_mac() -> Mac {
         let key = Key::new(vec![11u8, 19, 228, 209, 79, 189, 200, 59, 166, 47, 86, 254, 235, 184,
                                 120, 197, 75, 152, 201, 79, 115, 61, 111, 242, 219, 187, 173, 14,
                                 227, 108, 60, 232],
-                           &digest::SHA256);
+                           MessageDigest::sha256()).unwrap();
         Mac::new(MacType::Header,
                  &key,
                  Timespec::new(1353832834, 100),

--- a/hawk/src/credentials.rs
+++ b/hawk/src/credentials.rs
@@ -1,24 +1,37 @@
-use ring::{digest, hmac};
+use error::*;
+use openssl::hash::MessageDigest;
+use openssl::pkey::{PKey, Private};
+use openssl::sign::Signer;
 
 /// Hawk key.
 ///
 /// While any sequence of bytes can be specified as a key, note that each digest algorithm has
 /// a suggested key length, and that passwords should *not* be used as keys.  Keys of incorrect
 /// length are handled according to the digest's implementation.
-pub struct Key(hmac::SigningKey);
+pub struct Key {
+    key: PKey<Private>,
+    digest: MessageDigest
+}
 
 impl Key {
-    pub fn new<B>(key: B, algorithm: &'static digest::Algorithm) -> Key
+    pub fn new<B>(key: B, digest: MessageDigest) -> Result<Key>
         where B: Into<Vec<u8>>
     {
-        Key(hmac::SigningKey::new(algorithm, key.into().as_ref()))
+        let key = PKey::hmac(key.into().as_ref()).chain_err(|| "Key creation failed")?;
+        Ok(Key {
+            key,
+            digest
+        })
     }
 
-    pub fn sign(&self, data: &[u8]) -> Vec<u8> {
-        let digest = hmac::sign(&self.0, data);
-        let mut mac = vec![0; self.0.digest_algorithm().output_len];
+    pub fn sign(&self, data: &[u8]) -> Result<Vec<u8>> {
+        let mut hmac_signer = Signer::new(self.digest.clone(), &self.key)
+            .chain_err(|| "Cannot instanciate HMAC signer.")?;
+        hmac_signer.update(&data).chain_err(|| "Cannot feed data to signer.")?;
+        let digest = hmac_signer.sign_to_vec().chain_err(|| "Cannot create signature.")?;
+        let mut mac = vec![0; self.digest.size()];
         mac.clone_from_slice(digest.as_ref());
-        mac
+        Ok(mac)
     }
 }
 
@@ -33,19 +46,18 @@ pub struct Credentials {
 #[cfg(test)]
 mod test {
     use super::*;
-    use ring::digest;
 
     #[test]
     fn test_new_sha256() {
         let key = vec![77u8; 32];
         // hmac::SigningKey doesn't allow any visibilty inside, so we just build the
         // key and assume it works..
-        Key::new(key, &digest::SHA256);
+        Key::new(key, MessageDigest::sha256()).unwrap();
     }
 
     #[test]
     fn test_new_sha256_bad_length() {
         let key = vec![0u8; 99];
-        Key::new(key, &digest::SHA256);
+        Key::new(key, MessageDigest::sha256()).unwrap();
     }
 }

--- a/hawk/src/lib.rs
+++ b/hawk/src/lib.rs
@@ -14,16 +14,16 @@
 //! extern crate time;
 //! extern crate hawk;
 //!
-//! use hawk::{RequestBuilder, Credentials, Key, SHA256, PayloadHasher};
+//! use hawk::{RequestBuilder, Credentials, Key, Digest, PayloadHasher};
 //!
 //! fn main() {
 //!     // provide the Hawk id and key
 //!     let credentials = Credentials {
 //!         id: "test-client".to_string(),
-//!         key: Key::new(vec![99u8; 32], &SHA256),
+//!         key: Key::new(vec![99u8; 32], Digest::sha256()).unwrap(),
 //!     };
 //!
-//!     let payload_hash = PayloadHasher::hash("text/plain", &SHA256, "request-body");
+//!     let payload_hash = PayloadHasher::hash("text/plain", Digest::sha256(), "request-body").unwrap();
 //!
 //!     // provide the details of the request to be authorized
 //!      let request = RequestBuilder::new("POST", "example.com", 80, "/v1/users")
@@ -50,7 +50,7 @@
 //! extern crate time;
 //! extern crate hawk;
 //!
-//! use hawk::{RequestBuilder, Header, Key, SHA256};
+//! use hawk::{RequestBuilder, Header, Key, Digest};
 //! use hawk::mac::Mac;
 //!
 //! fn main() {
@@ -73,14 +73,14 @@
 //!        .hash(&hash[..])
 //!        .request();
 //!
-//!    let key = Key::new(vec![99u8; 32], &SHA256);
+//!    let key = Key::new(vec![99u8; 32], Digest::sha256()).unwrap();
 //!    if !request.validate_header(&hdr, &key, time::Duration::weeks(5200)) {
 //!        panic!("header validation failed. Is it 2117 already?");
 //!    }
 //! }
 extern crate base64;
 extern crate time;
-extern crate ring;
+extern crate openssl;
 extern crate url;
 extern crate rand;
 
@@ -115,4 +115,4 @@ pub use bewit::Bewit;
 pub mod mac;
 
 // convenience imports
-pub use ring::digest::{SHA256, SHA384, SHA512};
+pub use openssl::hash::MessageDigest as Digest;

--- a/hawk/src/payload.rs
+++ b/hawk/src/payload.rs
@@ -1,81 +1,85 @@
-use ring::digest;
+use error::*;
+use openssl::hash::{Hasher, MessageDigest};
 
 /// A utility for hashing payloads. Feed your entity body to this, then pass the `finish`
 /// result to a request or response.
 pub struct PayloadHasher {
-    context: digest::Context,
-    algorithm: &'static digest::Algorithm,
+    hasher: Hasher,
+    digest: MessageDigest,
 }
 
 impl PayloadHasher {
     /// Create a new PayloadHasher. The `content_type` should be lower-case and should
     /// not include parameters. The digest is assumed to be the same as the digest used
     /// for the credentials in the request.
-    pub fn new<B>(content_type: B, algorithm: &'static digest::Algorithm) -> Self
+    pub fn new<B>(content_type: B, digest: MessageDigest) -> Result<Self>
         where B: AsRef<[u8]>
     {
+        let hasher = Hasher::new(digest.clone()).chain_err(|| "Could not get hasher")?;
         let mut hasher = PayloadHasher {
-            context: digest::Context::new(algorithm),
-            algorithm: algorithm,
+            hasher,
+            digest,
         };
-        hasher.update(b"hawk.1.payload\n");
-        hasher.update(content_type.as_ref());
-        hasher.update(b"\n");
-        hasher
+        hasher.update(b"hawk.1.payload\n")?;
+        hasher.update(content_type.as_ref())?;
+        hasher.update(b"\n")?;
+        Ok(hasher)
     }
 
     /// Hash a single value and return it
     pub fn hash<B1, B2>(content_type: B1,
-                        algorithm: &'static digest::Algorithm,
+                        digest: MessageDigest,
                         payload: B2)
-                        -> Vec<u8>
+                        -> Result<Vec<u8>>
         where B1: AsRef<[u8]>,
               B2: AsRef<[u8]>
     {
-        let mut hasher = PayloadHasher::new(content_type, algorithm);
-        hasher.update(payload);
+        let mut hasher = PayloadHasher::new(content_type, digest)?;
+        hasher.update(payload)?;
         hasher.finish()
     }
 
     /// Update the hash with new data.
-    pub fn update<B>(&mut self, data: B)
+    pub fn update<B>(&mut self, data: B) -> Result<()>
         where B: AsRef<[u8]>
     {
-        self.context.update(data.as_ref());
+        self.hasher.update(data.as_ref()).chain_err(|| "Could not feed data to hasher")?;
+        Ok(())
     }
 
     /// Finish hashing and return the result
     ///
     /// Note that this appends a newline to the payload, as does the JS Hawk implementaiton.
-    pub fn finish(mut self) -> Vec<u8> {
-        self.update(b"\n");
-        let digest = self.context.finish();
-        let mut rv = vec![0; self.algorithm.output_len];
+    pub fn finish(mut self) -> Result<Vec<u8>> {
+        self.update(b"\n")?;
+        let digest = self.hasher.finish().chain_err(|| "Could get hasher data")?;
+        let mut rv = vec![0; self.digest.size()];
         rv.clone_from_slice(digest.as_ref());
-        rv
+        Ok(rv)
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::PayloadHasher;
-    use ring::digest::SHA256;
+    use openssl::hash::{MessageDigest};
 
     #[test]
     fn hash_consistency() {
-        let mut hasher1 = PayloadHasher::new("text/plain", &SHA256);
-        hasher1.update("pày");
-        hasher1.update("load");
-        let hash1 = hasher1.finish();
+        let mut hasher1 = PayloadHasher::new("text/plain", MessageDigest::sha256()).unwrap();
+        hasher1.update("pày").unwrap();
+        hasher1.update("load").unwrap();
+        let hash1 = hasher1.finish().unwrap();
 
-        let mut hasher2 = PayloadHasher::new("text/plain", &SHA256);
-        hasher2.update("pàyload");
-        let hash2 = hasher2.finish();
+        let mut hasher2 = PayloadHasher::new("text/plain", MessageDigest::sha256()).unwrap();
+        hasher2.update("pàyload").unwrap();
+        let hash2 = hasher2.finish().unwrap();
 
-        let hash3 = PayloadHasher::hash("text/plain", &SHA256, "pàyload");
+        let hash3 = PayloadHasher::hash("text/plain", MessageDigest::sha256(), "pàyload").unwrap();
 
         let hash4 = // "pàyload" as utf-8 bytes
-            PayloadHasher::hash("text/plain", &SHA256, vec![112, 195, 160, 121, 108, 111, 97, 100]);
+            PayloadHasher::hash("text/plain",
+                                MessageDigest::sha256(), vec![112, 195, 160, 121, 108, 111, 97, 100]).unwrap();
 
         assert_eq!(hash1,
                    vec![228, 238, 241, 224, 235, 114, 158, 112, 211, 254, 118, 89, 25, 236, 87,

--- a/hawk/src/request.rs
+++ b/hawk/src/request.rs
@@ -367,7 +367,7 @@ mod test {
     use credentials::{Credentials, Key};
     use header::Header;
     use url::Url;
-    use ring::digest;
+    use openssl::hash::{MessageDigest};
     use std::str::FromStr;
 
     // this is a header from a real request using the JS Hawk library, to
@@ -435,7 +435,7 @@ mod test {
         let req = RequestBuilder::new("GET", "example.com", 443, "/foo").request();
         let credentials = Credentials {
             id: "me".to_string(),
-            key: Key::new(vec![99u8; 32], &digest::SHA256),
+            key: Key::new(vec![99u8; 32], MessageDigest::sha256()).unwrap(),
         };
         let header = req.make_header_full(&credentials, Timespec::new(1000, 100), "nonny")
             .unwrap();
@@ -465,7 +465,7 @@ mod test {
             .request();
         let credentials = Credentials {
             id: "me".to_string(),
-            key: Key::new(vec![99u8; 32], &digest::SHA256),
+            key: Key::new(vec![99u8; 32], MessageDigest::sha256()).unwrap(),
         };
         let header = req.make_header_full(&credentials, Timespec::new(1000, 100), "nonny")
             .unwrap();
@@ -490,7 +490,7 @@ mod test {
         let req = RequestBuilder::new("GET", "example.com", 443, "/foo").request();
         let credentials = Credentials {
             id: "me".to_string(),
-            key: Key::new(vec![99u8; 32], &digest::SHA256),
+            key: Key::new(vec![99u8; 32], MessageDigest::sha256()).unwrap(),
         };
         let header = req.make_header_full(&credentials, now().to_timespec(), "nonny")
             .unwrap();
@@ -502,7 +502,7 @@ mod test {
         let header = Header::from_str(REAL_HEADER).unwrap();
         let credentials = Credentials {
             id: "me".to_string(),
-            key: Key::new("tok", &digest::SHA256),
+            key: Key::new("tok", MessageDigest::sha256()).unwrap(),
         };
         let req = RequestBuilder::new("GET", "pulse.taskcluster.net", 443, "/v1/namespaces")
             .request();
@@ -516,7 +516,7 @@ mod test {
         let header = Header::from_str(REAL_HEADER).unwrap();
         let credentials = Credentials {
             id: "me".to_string(),
-            key: Key::new("WRONG", &digest::SHA256),
+            key: Key::new("WRONG", MessageDigest::sha256()).unwrap(),
         };
         let req = RequestBuilder::new("GET", "pulse.taskcluster.net", 443, "/v1/namespaces")
             .request();
@@ -528,7 +528,7 @@ mod test {
         let header = Header::from_str(REAL_HEADER).unwrap();
         let credentials = Credentials {
             id: "me".to_string(),
-            key: Key::new("tok", &digest::SHA256),
+            key: Key::new("tok", MessageDigest::sha256()).unwrap(),
         };
         let req = RequestBuilder::new("GET", "pulse.taskcluster.net", 443, "WRONG PATH").request();
         assert!(!req.validate_header(&header, &credentials.key, Duration::weeks(52000)));
@@ -567,7 +567,7 @@ mod test {
         let header = make_header_without_hash();
         let req = RequestBuilder::new("", "", 0, "").request();
         assert!(req.validate_header(&header,
-                                    &Key::new("tok", &digest::SHA256),
+                                    &Key::new("tok", MessageDigest::sha256()).unwrap(),
                                     Duration::weeks(52000)));
     }
 
@@ -576,7 +576,7 @@ mod test {
         let header = make_header_with_hash();
         let req = RequestBuilder::new("", "", 0, "").request();
         assert!(req.validate_header(&header,
-                                    &Key::new("tok", &digest::SHA256),
+                                    &Key::new("tok", MessageDigest::sha256()).unwrap(),
                                     Duration::weeks(52000)));
     }
 
@@ -588,7 +588,7 @@ mod test {
             .hash(Some(&hash[..]))
             .request();
         assert!(!req.validate_header(&header,
-                                     &Key::new("tok", &digest::SHA256),
+                                     &Key::new("tok", MessageDigest::sha256()).unwrap(),
                                      Duration::weeks(52000)));
     }
 
@@ -600,7 +600,7 @@ mod test {
             .hash(Some(&hash[..]))
             .request();
         assert!(req.validate_header(&header,
-                                    &Key::new("tok", &digest::SHA256),
+                                    &Key::new("tok", MessageDigest::sha256()).unwrap(),
                                     Duration::weeks(52000)));
 
         // ..but supplying the wrong hash will cause validation to fail
@@ -609,14 +609,14 @@ mod test {
             .hash(Some(&hash[..]))
             .request();
         assert!(!req.validate_header(&header,
-                                     &Key::new("tok", &digest::SHA256),
+                                     &Key::new("tok", MessageDigest::sha256()).unwrap(),
                                      Duration::weeks(52000)));
     }
 
     fn round_trip_bewit(req: Request, duration: Duration, expected: bool) {
         let credentials = Credentials {
             id: "me".to_string(),
-            key: Key::new("tok", &digest::SHA256),
+            key: Key::new("tok", MessageDigest::sha256()).unwrap(),
         };
 
         let bewit = req.make_bewit(&credentials, duration).unwrap();

--- a/hawk/src/response.rs
+++ b/hawk/src/response.rs
@@ -188,7 +188,7 @@ mod test {
     use credentials::Key;
     use mac::Mac;
     use time::Timespec;
-    use ring::digest;
+    use openssl::hash::{MessageDigest};
 
     fn make_req_header() -> Header {
         Header::new(None,
@@ -220,7 +220,7 @@ mod test {
                                         None,
                                         None)
             .unwrap();
-        assert!(resp.validate_header(&server_header, &Key::new("tok", &digest::SHA256)));
+        assert!(resp.validate_header(&server_header, &Key::new("tok", MessageDigest::sha256()).unwrap()));
     }
 
     #[test]
@@ -243,7 +243,7 @@ mod test {
                                         None,
                                         None)
             .unwrap();
-        assert!(resp.validate_header(&server_header, &Key::new("tok", &digest::SHA256)));
+        assert!(resp.validate_header(&server_header, &Key::new("tok", MessageDigest::sha256()).unwrap()));
     }
 
     #[test]
@@ -267,7 +267,7 @@ mod test {
                                         None,
                                         None)
             .unwrap();
-        assert!(!resp.validate_header(&server_header, &Key::new("tok", &digest::SHA256)));
+        assert!(!resp.validate_header(&server_header, &Key::new("tok", MessageDigest::sha256()).unwrap()));
     }
 
     #[test]
@@ -292,7 +292,7 @@ mod test {
                                         None,
                                         None)
             .unwrap();
-        assert!(resp.validate_header(&server_header, &Key::new("tok", &digest::SHA256)));
+        assert!(resp.validate_header(&server_header, &Key::new("tok", MessageDigest::sha256()).unwrap()));
 
         // a different supplied hash won't match..
         let hash = vec![99, 99, 99, 99];
@@ -300,6 +300,6 @@ mod test {
             ResponseBuilder::from_request_header(&req_header, "POST", "localhost", 9988, "/a/b")
                 .hash(&hash[..])
                 .response();
-        assert!(!resp.validate_header(&server_header, &Key::new("tok", &digest::SHA256)));
+        assert!(!resp.validate_header(&server_header, &Key::new("tok", MessageDigest::sha256()).unwrap()));
     }
 }


### PR DESCRIPTION
We are using `rust-hawk` in some applications that have a dependency on [rust-openssl](https://github.com/sfackler/rust-openssl) for different reasons.
`rust-hawk` itself depends on `ring` (2.2mb compiled with `cargo build --release`) for operations that could be done with `rust-openssl` instead, hence this PR.